### PR TITLE
build: :hammer: split out quartodoc step with render step

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,14 +60,17 @@ format-python:
 format-md:
   uvx rumdl fmt --silent
 
-# Build the documentation website using Quarto
-build-website:
+# Build the quartodoc documentation for the website
+build-quartodoc:
   # To let Quarto know where python is.
   export QUARTO_PYTHON=.venv/bin/python3
   # Delete any previously built files from quartodoc.
   # -f is to not give an error if the files don't exist yet.
   rm -rf docs/reference
   uv run quartodoc build
+
+# Build the documentation website using Quarto
+build-website:
   uv run quarto render --execute
 
 # Check the commit messages on the current branch that are not on the main branch


### PR DESCRIPTION
# Description

Right now we don't have quartodoc set up, so running `just run-all` gives an error. This splits it out so that it also doesn't run every time.

Needs a quick review.

## Checklist

- [x] Ran `just run-all`
