### PR TITLE
refactor: :truck: reorganise files

### DIFF
--- a/src/zen_do/__init__.py
+++ b/src/zen_do/__init__.py
@@ -2,13 +2,11 @@
 
 from .cli import zenodo_publish
 from .examples import example_deposit, example_metadata
-from .zenodo import (
+from .zenodo_client import (
     ZenodoClient,
-    ZenodoCreator,
     ZenodoDepositState,
-    ZenodoMetadata,
-    ZenodoRelatedIdentifier,
 )
+from .zenodo_metadata import ZenodoCreator, ZenodoMetadata, ZenodoRelatedIdentifier
 
 __all__ = [
     "example_metadata",

--- a/src/zen_do/cli.py
+++ b/src/zen_do/cli.py
@@ -5,7 +5,8 @@ from seedcase_soil import (
 )
 
 from zen_do.get_token import get_token
-from zen_do.zenodo import ZenodoClient, zenodo_get_deposit
+from zen_do.zenodo_client import ZenodoClient
+from zen_do.zenodo_get_deposit import zenodo_get_deposit
 
 app = setup_cli(
     name="zen-do",

--- a/src/zen_do/examples.py
+++ b/src/zen_do/examples.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
-from zen_do.zenodo import (
-    ZenodoCreator,
+from zen_do.zenodo_client import (
     ZenodoDepositState,
+    ZenodoResponse,
+)
+from zen_do.zenodo_metadata import (
+    ZenodoCreator,
     ZenodoMetadata,
     ZenodoRelatedIdentifier,
-    ZenodoResponse,
 )
 
 

--- a/src/zen_do/zenodo_client.py
+++ b/src/zen_do/zenodo_client.py
@@ -1,72 +1,10 @@
-import re
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Optional, Self, Union
+from typing import Any, Union
 
 import requests
-import seedcase_soil as so
-from pydantic import BaseModel, model_validator
 
-
-class ZenodoCreator(BaseModel):
-    """Model representing the creator of a Zenodo deposit.
-
-    Attributes:
-        name: The name of the creator.
-        affiliation: The affiliation of the creator.
-        orcid: The ORCID of the creator.
-    """
-
-    name: str
-    affiliation: str
-    orcid: str
-
-
-class ZenodoRelatedIdentifier(BaseModel):
-    """Model representing an identifier related to a Zenodo deposit.
-
-    Attributes:
-        identifier: The value of the identifier.
-        relation: The relationship between the deposit and the other piece of work
-            identified by the identifier.
-        resource_type: The type of the work identified by the identifier.
-        scheme: The scheme followed by the identifier.
-    """
-
-    identifier: str
-    relation: str
-    resource_type: str
-    scheme: Optional[str] = None
-
-    @model_validator(mode="after")
-    def _check_urn(self) -> Self:
-
-        if self.scheme == "urn" and not re.fullmatch(
-            r"urn:zenodo(:[^/:]+)+", self.identifier
-        ):
-            raise ValueError(
-                f"The URN {self.identifier!r} does not have the expected format. URNs "
-                "must be in the format 'urn:zenodo:<unique-id>(:<optional-sub-id>)'. "
-                "We recommend 'urn:zenodo:<github-username>:<repo-name>:<output-type>'."
-            )
-        return self
-
-
-class ZenodoMetadata(BaseModel):
-    """Model representing Zenodo metadata.
-
-    Attributes:
-        title: The title of the deposit.
-        upload_type: The type of the deposit.
-        creators: The creators of the deposit.
-        related_identifiers: Identifiers related to the deposit.
-    """
-
-    title: str
-    upload_type: str
-    creators: list[ZenodoCreator]
-    related_identifiers: list[ZenodoRelatedIdentifier] = []
-
+from zen_do.zenodo_metadata import ZenodoMetadata
 
 type ZenodoResponse = dict[str, Any]
 
@@ -95,66 +33,6 @@ def _is_deposit_editable(deposit: ZenodoResponse) -> bool:
         ZenodoDepositState.inprogress,
         ZenodoDepositState.unsubmitted,
     ]
-
-
-def zenodo_get_deposit(deposits: list[ZenodoResponse]) -> Optional[ZenodoResponse]:
-    """Gets the Zenodo deposit for the repository if it exists.
-
-    Gets the URN identifier from the `.zenodo.json` file. If one
-    doesn't exist, this function will not work.
-
-    Args:
-        deposits: All the deposits on Zenodo associated with an access token.
-
-    Returns:
-        The Zenodo deposit for the repo if it exists, None otherwise.
-    """
-    urn = _get_urn()
-
-    matching_deposits = so.keep(
-        deposits,
-        lambda deposit: bool(
-            so.keep(
-                _get_zenodo_field(deposit, "metadata").get("related_identifiers", []),
-                lambda id: _urn_matches(id, urn),
-            )
-        ),
-    )
-
-    if len(matching_deposits) > 1:
-        raise ValueError(
-            "There are multiple deposits on Zenodo with the URN "
-            f"{urn!r} as a `related identifier`. We only allow one."
-        )
-    if not matching_deposits:
-        return None
-    return matching_deposits[0]
-
-
-def _load_zenodo_json() -> ZenodoMetadata:
-    return ZenodoMetadata.model_validate_json(Path(".zenodo.json").read_text())
-
-
-def _urn_matches(id_response: ZenodoResponse, target_urn: str) -> bool:
-    id = ZenodoRelatedIdentifier.model_construct(**id_response)
-    return _is_urn(id) and id.identifier == target_urn
-
-
-def _is_urn(id: ZenodoRelatedIdentifier) -> bool:
-    return id.relation == "isIdenticalTo" and id.scheme == "urn"
-
-
-def _get_urn() -> str:
-    metadata = _load_zenodo_json()
-    ids = so.keep(metadata.related_identifiers, _is_urn)
-    if len(ids) != 1:
-        raise ValueError(
-            "Expected exactly one `isIdenticalTo` URN in `.zenodo.json` under "
-            f"`related_identifiers`, but found {len(ids)}. Ensure there is a single "
-            "unique URN, as it is used to identify the corresponding deposit on Zenodo."
-        )
-
-    return ids[0].identifier
 
 
 class ZenodoClient:

--- a/src/zen_do/zenodo_get_deposit.py
+++ b/src/zen_do/zenodo_get_deposit.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+from typing import Optional
+
+import seedcase_soil as so
+
+from zen_do.zenodo_client import ZenodoResponse, _get_zenodo_field
+from zen_do.zenodo_metadata import ZenodoMetadata, ZenodoRelatedIdentifier
+
+
+def zenodo_get_deposit(deposits: list[ZenodoResponse]) -> Optional[ZenodoResponse]:
+    """Gets the Zenodo deposit for the repository if it exists.
+
+    Gets the URN identifier from the `.zenodo.json` file. If one
+    doesn't exist, this function will not work.
+
+    Args:
+        deposits: All the deposits on Zenodo associated with an access token.
+
+    Returns:
+        The Zenodo deposit for the repo if it exists, None otherwise.
+    """
+    urn = _get_urn()
+
+    matching_deposits = so.keep(
+        deposits,
+        lambda deposit: bool(
+            so.keep(
+                _get_zenodo_field(deposit, "metadata").get("related_identifiers", []),
+                lambda id: _urn_matches(id, urn),
+            )
+        ),
+    )
+
+    if len(matching_deposits) > 1:
+        raise ValueError(
+            "There are multiple deposits on Zenodo with the URN "
+            f"{urn!r} as a `related identifier`. We only allow one."
+        )
+    if not matching_deposits:
+        return None
+    return matching_deposits[0]
+
+
+def _load_zenodo_json() -> ZenodoMetadata:
+    return ZenodoMetadata.model_validate_json(Path(".zenodo.json").read_text())
+
+
+def _urn_matches(id_response: ZenodoResponse, target_urn: str) -> bool:
+    id = ZenodoRelatedIdentifier.model_construct(**id_response)
+    return _is_urn(id) and id.identifier == target_urn
+
+
+def _is_urn(id: ZenodoRelatedIdentifier) -> bool:
+    return id.relation == "isIdenticalTo" and id.scheme == "urn"
+
+
+def _get_urn() -> str:
+    metadata = _load_zenodo_json()
+    ids = so.keep(metadata.related_identifiers, _is_urn)
+    if len(ids) != 1:
+        raise ValueError(
+            "Expected exactly one `isIdenticalTo` URN in `.zenodo.json` under "
+            f"`related_identifiers`, but found {len(ids)}. Ensure there is a single "
+            "unique URN, as it is used to identify the corresponding deposit on Zenodo."
+        )
+
+    return ids[0].identifier

--- a/src/zen_do/zenodo_metadata.py
+++ b/src/zen_do/zenodo_metadata.py
@@ -1,0 +1,64 @@
+import re
+from typing import Optional, Self
+
+from pydantic import BaseModel, model_validator
+
+
+class ZenodoCreator(BaseModel):
+    """Model representing the creator of a Zenodo deposit.
+
+    Attributes:
+        name: The name of the creator.
+        affiliation: The affiliation of the creator.
+        orcid: The ORCID of the creator.
+    """
+
+    name: str
+    affiliation: str
+    orcid: str
+
+
+class ZenodoRelatedIdentifier(BaseModel):
+    """Model representing an identifier related to a Zenodo deposit.
+
+    Attributes:
+        identifier: The value of the identifier.
+        relation: The relationship between the deposit and the other piece of work
+            identified by the identifier.
+        resource_type: The type of the work identified by the identifier.
+        scheme: The scheme followed by the identifier.
+    """
+
+    identifier: str
+    relation: str
+    resource_type: str
+    scheme: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _check_urn(self) -> Self:
+
+        if self.scheme == "urn" and not re.fullmatch(
+            r"urn:zenodo(:[^/:]+)+", self.identifier
+        ):
+            raise ValueError(
+                f"The URN {self.identifier!r} does not have the expected format. URNs "
+                "must be in the format 'urn:zenodo:<unique-id>(:<optional-sub-id>)'. "
+                "We recommend 'urn:zenodo:<github-username>:<repo-name>:<output-type>'."
+            )
+        return self
+
+
+class ZenodoMetadata(BaseModel):
+    """Model representing Zenodo metadata.
+
+    Attributes:
+        title: The title of the deposit.
+        upload_type: The type of the deposit.
+        creators: The creators of the deposit.
+        related_identifiers: Identifiers related to the deposit.
+    """
+
+    title: str
+    upload_type: str
+    creators: list[ZenodoCreator]
+    related_identifiers: list[ZenodoRelatedIdentifier] = []

--- a/tests/test_zenodo_client.py
+++ b/tests/test_zenodo_client.py
@@ -6,7 +6,7 @@ import requests
 from pytest import mark, raises
 
 from zen_do.examples import example_deposit, example_metadata
-from zen_do.zenodo import ZenodoClient, ZenodoDepositState
+from zen_do.zenodo_client import ZenodoClient, ZenodoDepositState
 
 sandbox_client = ZenodoClient(sandbox=True, token="token")
 

--- a/tests/test_zenodo_get_deposit.py
+++ b/tests/test_zenodo_get_deposit.py
@@ -4,10 +4,8 @@ from pathlib import Path
 from pytest import MonkeyPatch, fixture, mark, raises
 
 from zen_do.examples import example_deposit, example_metadata
-from zen_do.zenodo import (
-    ZenodoRelatedIdentifier,
-    zenodo_get_deposit,
-)
+from zen_do.zenodo_get_deposit import zenodo_get_deposit
+from zen_do.zenodo_metadata import ZenodoRelatedIdentifier
 
 
 @fixture

--- a/uv.lock
+++ b/uv.lock
@@ -1725,22 +1725,22 @@ wheels = [
 
 [[package]]
 name = "plum-dispatch"
-version = "2.8.0"
+version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/2f2b0dd84edbb2951a845ba98d29f651bbbd467039c368fcfa22904905cd/plum_dispatch-2.8.0.tar.gz", hash = "sha256:453fc7bc67d2a39492c834b00c94d816871d148b5a0a5d3f49e2bbf2391e2619", size = 241272, upload-time = "2026-03-17T21:24:41.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/b7/84146ae5ff6c40d11357acdb36aafe3db7e104de01c1026d8e1b0ce3e7f1/plum_dispatch-2.9.0.tar.gz", hash = "sha256:fb45c5b2dd4dadd57def51bcf321dfa3a258df5c725f43adea7e7f6db3b79b52", size = 244502, upload-time = "2026-04-28T08:38:34.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/a3/cdb8130cc05a13c75237d2be4821f38c0b99d1a64980b6529d788a43a501/plum_dispatch-2.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fca6b6dbed8c686f6f827e9c95f60334ba70ee27cccef1f44a50d42a30221748", size = 165288, upload-time = "2026-03-17T21:24:31.203Z" },
-    { url = "https://files.pythonhosted.org/packages/25/fe/b1dbbdd1864d4ca825b3b5079fca852ea5e5a4f223aa866702f751b02dba/plum_dispatch-2.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:599025e7bd7e16f198e5ccaad0ca51036fcbeb43eb41525a5ef705b9a25bb192", size = 194360, upload-time = "2026-03-17T21:24:32.531Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/01/a8947d5c92824a6bc019696e5d9f150178736ecd8e6766db38b38e0f0fda/plum_dispatch-2.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:c0e6146881b71eb6a6355d18476bed356071d1dff45a7cf4ae31f7f4bffb01b9", size = 146826, upload-time = "2026-03-17T21:24:34.076Z" },
-    { url = "https://files.pythonhosted.org/packages/68/25/380300b3468417999ca0db0522eeae1017798519fe28753e8ad110718174/plum_dispatch-2.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d60c0040207495afddab3f80c498a5e8f9dab29f8d143468c51d668fe70ed291", size = 165256, upload-time = "2026-03-17T21:24:35.341Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/94e4e62ad437996341d03471bd398f3f6bf4c5f3a1fa524ba53f02b6896d/plum_dispatch-2.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88aaf08a562e7a559851679a051b32306b67fd403ed6070915a966f048a83e9", size = 193632, upload-time = "2026-03-17T21:24:37.035Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/d2/772d1e3071971a30e70b78df421f51788354337a7f94957d910ba3cd8a5a/plum_dispatch-2.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:53bc084b335e5071b72353830a9f2cdacd58c9e959089be5778b6d638b5062f9", size = 146931, upload-time = "2026-03-17T21:24:38.8Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/7d/6d1a0a5851fb590564045471bdd6f405426ae4214cafe530ceba297e5c0d/plum_dispatch-2.8.0-py3-none-any.whl", hash = "sha256:f5dfffc46de1d8208ba281fdb0f41d6065c7341c1fde76fc83b4b78810c30c7e", size = 44547, upload-time = "2026-03-17T21:24:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d6/fc6591336731b5e291319ec3c43d81cd6cc7940c9079183b333b85ed4d77/plum_dispatch-2.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:39a325b0b041fad687271d71abc11b5271d5a3b62af2c6b1271f4ececc3b59de", size = 175166, upload-time = "2026-04-28T08:38:24.467Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4d/5418649397b477ae08839564c97596ede5ef36523147899bb913bbe959d1/plum_dispatch-2.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d39b20a1af776a39e4a0833e97c6258d938e5d874c7f3537bb7d772c39718c1e", size = 205988, upload-time = "2026-04-28T08:38:25.838Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a5/28a6c4e45c4465a6e1a30d65206e913c217690752dc3c9261d78a9187aed/plum_dispatch-2.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:beb9b92c6994404a0d2dc83c857263f5da49519575e5cbb8a13060652746c44c", size = 152563, upload-time = "2026-04-28T08:38:27.37Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/18/19e01dbbaececb75815abb37bc71e10d87a7561829b4eae47ec3b342c94f/plum_dispatch-2.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78987caf558fbdd675a7a4a5c144069f1f9524610195123fb7d0f0234d0af01a", size = 174490, upload-time = "2026-04-28T08:38:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/29/7b3de57cd86430fd00d71bc5a8a078bf2c63d4ada7fdfb30853fe976a19f/plum_dispatch-2.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36662d76ae6d87aaa041fade036d2242f0b88b68c9fb4c96b7ba0026320065d3", size = 204734, upload-time = "2026-04-28T08:38:30.398Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/98/23d19326af0da251bb98a39f517ab6da983e5aad5eb9cc398b60933df2cc/plum_dispatch-2.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0d16daf09482a6588025e9f133a338d99474e8dd3c3dbbc4c5282a4fffe5a0e", size = 152624, upload-time = "2026-04-28T08:38:31.886Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a7/ee4d01d26032b060d379f44a29124180f756d907e3840d3bc450f8a0d2a7/plum_dispatch-2.9.0-py3-none-any.whl", hash = "sha256:5a516cdac5460343937a2b813562ac00b0eeac973ac023916e538610bdf34397", size = 45328, upload-time = "2026-04-28T08:38:33.022Z" },
 ]
 
 [[package]]
@@ -2619,19 +2619,19 @@ wheels = [
 
 [[package]]
 name = "typos"
-version = "1.45.1"
+version = "1.45.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/c2/0cd9200d030f8e3c71ac30bc0ee86736d9d7d0a9b02c1b050f40138c19c0/typos-1.45.1.tar.gz", hash = "sha256:a1ac7ab02e74d4c4a2f8525b1529e1ce6261051df3229701836175fb91bb0583", size = 1820481, upload-time = "2026-04-13T15:03:01.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/f6/4d6647ddc98c9aaa3522bf9cadec8d098cf4acebdeaabe00cfa46d7210a8/typos-1.45.2.tar.gz", hash = "sha256:baa93e3eac9eddda673ffd93af7c7de88bd82e9dfaa5080da8895acb40ef1f27", size = 1820715, upload-time = "2026-04-27T16:08:38.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/49/e0e0614d635f4847de1c3464ee068be579dfe14a81dd9051fa6fc3653305/typos-1.45.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f3cd3d7e7e35f971e04974c7b34563dc1efb101841be3a39fec36c51f3d6ca2d", size = 3480310, upload-time = "2026-04-13T15:02:43.19Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/f5/b0fc73ab073eb844e888cf47c8fc1fab3b59eaf8becbb901b58e46ded7e2/typos-1.45.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:be6f26c580915e63df107f88bc766f131efe5f7d01d41c7bad83e6f9e5fe42be", size = 3381483, upload-time = "2026-04-13T15:02:45.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/e1/1b1c8ff64d61143206e700fe4ae6732749053e44d10a33d9da1eceecbadc/typos-1.45.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cd6a6ccbb1fc4fb8f0d9fee0201642d7a7560bd1661ebbefb9eac2da1ae4a5c", size = 8247207, upload-time = "2026-04-13T15:02:47.658Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/6b/79ccb79cab37c04a10759709042476b8534f3f2f6a89180f67821f396482/typos-1.45.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d33c7750a29524dff020a17f356ed079227f36f43ec57f193e9681606a35749b", size = 7361395, upload-time = "2026-04-13T15:02:49.564Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/4c/b97fbabf0413edda31e1e830befb267f934e990a417a11e1f6f6b2e1235e/typos-1.45.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:745b0584eeead4593858671113fceed3c28b8ca67bdc7a517120127aa509c6a6", size = 7757620, upload-time = "2026-04-13T15:02:51.664Z" },
-    { url = "https://files.pythonhosted.org/packages/69/f8/1b757c9b83750100b6c2f09fb6d84d4521ca158c74d9a437495329fca58e/typos-1.45.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e962d414fb92ad31dc4c930fc5d07ac9e4b55fdd4f42688468040fc5649d92da", size = 7111197, upload-time = "2026-04-13T15:02:53.831Z" },
-    { url = "https://files.pythonhosted.org/packages/63/76/65c1d4248d9cb1b12fb4bad81b829bd5cc3da7564ffe0a794fac3126f1f4/typos-1.45.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f39afdfcc2d159705f3ffb11162e13e8affd994d07836738c8d2a592194604ab", size = 8180810, upload-time = "2026-04-13T15:02:55.901Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/b5/65b3e0509c3d698faf1a965a9afcfff3ebff50c850e789891945735f8066/typos-1.45.1-py3-none-win32.whl", hash = "sha256:212fdbb7b90d40522fe77efb69c15f7063c146812df01d5605e5d7816a3f37d3", size = 3135956, upload-time = "2026-04-13T15:02:57.934Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/50/a9ec45215912d8e8600ba903b09382144071b450ad2f7adebc63e7699b99/typos-1.45.1-py3-none-win_amd64.whl", hash = "sha256:67a56bd1f06184f3761883f4f75dd3cc196f939180de595d0980164d4a19d363", size = 3318717, upload-time = "2026-04-13T15:02:59.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/07/7a3c025118d2c174d1b066349db53a832a58f475e2415e0378c80637275c/typos-1.45.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:28b98456941c9862f72c4993c1c1cd272291a2c8a7dee98fa85393a500034e01", size = 3473968, upload-time = "2026-04-27T16:08:21.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/63/fb32620deaf035e6859929d3e83a13878a57d362d63abaeccee85b2fd4da/typos-1.45.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7a46fba84e87ca8e23e267b7c541dc3cf6cb1b426946b5269e9ae11e1e6bb4b1", size = 3379169, upload-time = "2026-04-27T16:08:23.831Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3a/88e9df6372cae3158b432983e1b741a4d45a18d08f4293c101686459c521/typos-1.45.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:401c681815cd1fe3599525b8e94aed014efe33b34f224a643a2d0b9a81b9c07e", size = 8231099, upload-time = "2026-04-27T16:08:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/80/26/c707af77c2d03a0a5f7f61f1c8f9efcb42806facc1f601f3630c734ceec5/typos-1.45.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4258e0d0b5e3cf3d291f42ff2bd9f92c7823a6b6c347f063b63d77fad088e7f6", size = 7323338, upload-time = "2026-04-27T16:08:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c3/1c004b9a7b8272838fd46a8bd3ec9776a42c72f913d42a7a483ef8bab8f9/typos-1.45.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f7136775ae5b8d44281fc7076ff44c2fe3511a2b2748d1b02aa3f596f04bf77", size = 7736378, upload-time = "2026-04-27T16:08:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/60/197fb77de6b77c1e95e0bc30957d08fb22883d1affe5a7f43f8bf1ca1a51/typos-1.45.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d570d19c02f44679e0cd44f8abfcddb7ece95935ca6033165c616a104531a7c8", size = 7093871, upload-time = "2026-04-27T16:08:31.797Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/81/3f9def82abe23f8903b5ef0bf5547e09672fd8ee318163ecfdc383f094e3/typos-1.45.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d04d569a00749b8e442a8f4132b46f2183d79b891a7bdb0001573b3f257c1b09", size = 8128418, upload-time = "2026-04-27T16:08:33.828Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e1/abf89012101697b014e19ad3f1979ca03261ebd141de4307be5bba4086ea/typos-1.45.2-py3-none-win32.whl", hash = "sha256:6140040f009536ff4aa1623671e491e6b197d2d92c03b3f4e43b9d3cf4de9560", size = 3133518, upload-time = "2026-04-27T16:08:35.589Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fe/7445e44793986be97117b331b63347d45272dc0f5148c88a00e1260e5353/typos-1.45.2-py3-none-win_amd64.whl", hash = "sha256:73f5c7f409f1467c48df0f63329ab68d01fcca9dbcb9042d0c9bc24873f69339", size = 3307752, upload-time = "2026-04-27T16:08:37.134Z" },
 ]
 
 [[package]]
@@ -2663,7 +2663,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -2671,9 +2671,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

This PR reorganises the files:
- `zenodo_client.py`: just the client. I really think this should live in its own file.
- `zenodo_get_deposit.py`: the function for finding the Zenodo deposit that matches the metadata file. This will be used in multiple CLI commands.
- `zenodo_metadata.py`: Pydantic classes for the metadata only.

I haven't removed `zenodo` from the names yet.

Closes #

Needs a quickish review.

## Checklist

- [x] Ran `just run-all`
